### PR TITLE
Support for Spring Boot DevTools Restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.3.0
+
+* Add support for shuting down the storage during application shutdown
+  * By default only enabled when Spring DevTools are active
+    * This should fix "StorageExceptionInitialization: Active storage for ... already exists" errors during DevTools restart
+
 # 2.2.2
 
 * Fixed NPE in EclipseSerializerRegisteringCopier

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,14 +1,14 @@
 name: ROOT
 title: Spring-Data-Eclipse-Store
 version: master
-display_version: '2.2.2'
+display_version: '2.3.0'
 start_page: index.adoc
 nav:
   - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
     product-name: 'Spring-Data-Eclipse-Store'
-    display-version: '2.2.2'
-    maven-version: '2.2.2'
+    display-version: '2.3.0'
+    maven-version: '2.3.0'
     page-editable: false
     page-out-of-support: false

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -28,3 +28,24 @@ public class DemoConfiguration extends EclipseStoreClientConfiguration
 The method ``createEmbeddedStorageFoundation`` could return a much more complicated ``EmbeddedStorageFoundation`` as described here in the https://docs.eclipsestore.io/manual/storage/configuration/index.html[EclipseStore documentation about configuration and foundations].
 
 This also enables you to use multiple EclipseStore-Storages in one project. See the https://github.com/xdev-software/spring-data-eclipse-store/tree/develop/spring-data-eclipse-store-demo/src/main/java/software/xdev/spring/data/eclipse/store/demo/dual/storage[Dual storages demo].
+
+== Properties
+
+In general properties from EclipseStore can be used.
+See https://docs.eclipsestore.io/manual/storage/configuration/properties.html[EclipseStore - Properties].
+
+Here the {product-name}-Properties are displayed (all must be prefixed with ``spring-data-eclipse-store``):
+
+[cols="1,1"]
+|===
+|https://github.com/xdev-software/spring-data-eclipse-store/tree/develop/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java[context-close-shutdown-storage.enabled] [[context-close-shutdown-storage]]
+| If enabled, the application listens to the ``ContextClosedEvent`` and shuts the storage down if the restart of the spring-dev-tools is enabled (see xref:known-issues.adoc#spring-dev-tools[Known issues] and https://docs.spring.io/spring-boot/api/java/org/springframework/boot/devtools/autoconfigure/DevToolsProperties.Restart.html[DevToolProperties])
+
+Default: ``true``
+
+|https://github.com/xdev-software/spring-data-eclipse-store/tree/develop/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java[context-close-shutdown-storage.only-when-dev-tools]
+|If this and ``context-close-shutdown-storage.enabled`` are true, the application listens to the ``ContextClosedEvent`` and shuts the storage down **only if** the spring-dev-tools are present in the ClassLoader (see xref:known-issues.adoc#spring-dev-tools[Known issues])
+
+Default: ``true``
+
+

--- a/docs/modules/ROOT/pages/known-issues.adoc
+++ b/docs/modules/ROOT/pages/known-issues.adoc
@@ -18,23 +18,14 @@ This helps you keep your data up to date regardless of the current version.
 
 We created https://github.com/xdev-software/spring-data-eclipse-store/issues/33[an issue] for that but right now we *do not support XDEVs MicroMigration*.
 
-== Spring Developer Tools
+== Spring Developer Tools [[spring-dev-tools]]
 
 Using https://docs.spring.io/spring-boot/reference/using/devtools.html[Spring Developer Tools] (`spring-boot-devtools`) can lead to serious issues in your project.
-That is manly due to the https://docs.spring.io/spring-boot/reference/using/devtools.html#using.devtools.livereload[LiveReload feature] and the usage of a "Restart Classloader".
+That is manly due to the https://docs.spring.io/spring-boot/reference/using/devtools.html#using.devtools.livereload[LiveReload feature] and the usage of a "Restart ClassLoader".
 It derives from the https://docs.eclipsestore.io/manual/misc/integrations/spring-boot.html#_spring_dev_tools[issue with EclipseStore].
 
-This leads to problems within EclipseStore and can cause issues with discovering beans (https://github.com/spring-projects/spring-boot/issues/41011[Example Issue]).
+To mitigate this issue, {product-name} listens to the closing of the Spring-Context and shuts down the storage.
+This **should** handle most problems with the ClassLoader.
+Restarting the storage leads to a reloading of all entities and may take some time, yet circumvents the Restart ClassLoader Issue.
 
-If you must use the Spring Developer Tools, make sure to https://docs.spring.io/spring-boot/reference/using/devtools.html#using.devtools.restart.disable[disable restart].
-
-[source,java,title="Example how to disable restart"]
-----
-@SpringBootApplication
-public class MyApplication {
-	public static void main(String[] args) {
-		System.setProperty("spring.devtools.restart.enabled", "false");
-		SpringApplication.run(MyApplication.class, args);
-	}
-}
-----
+The behavior can be configured through xref:configuration.adoc#context-close-shutdown-storage[Properties] and is implemented in the https://github.com/xdev-software/spring-data-eclipse-store/tree/develop/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java[EclipseStoreClientConfiguration.java].

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>software.xdev</groupId>
 	<artifactId>spring-data-eclipse-store-root</artifactId>
-	<version>2.2.3-SNAPSHOT</version>
+	<version>2.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<organization>

--- a/spring-data-eclipse-store-benchmark/pom.xml
+++ b/spring-data-eclipse-store-benchmark/pom.xml
@@ -5,11 +5,11 @@
 	<parent>
 		<groupId>software.xdev</groupId>
 		<artifactId>spring-data-eclipse-store-root</artifactId>
-		<version>2.2.3-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-eclipse-store-benchmark</artifactId>
-	<version>2.2.3-SNAPSHOT</version>
+	<version>2.3.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<inceptionYear>2023</inceptionYear>

--- a/spring-data-eclipse-store-demo/pom.xml
+++ b/spring-data-eclipse-store-demo/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>software.xdev</groupId>
 		<artifactId>spring-data-eclipse-store-root</artifactId>
-		<version>2.2.3-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-eclipse-store-demo</artifactId>
-	<version>2.2.3-SNAPSHOT</version>
+	<version>2.3.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<organization>

--- a/spring-data-eclipse-store-demo/src/main/java/software/xdev/spring/data/eclipse/store/demo/complex/ComplexConfiguration.java
+++ b/spring-data-eclipse-store-demo/src/main/java/software/xdev/spring/data/eclipse/store/demo/complex/ComplexConfiguration.java
@@ -2,6 +2,7 @@ package software.xdev.spring.data.eclipse.store.demo.complex;
 
 import java.nio.file.Path;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
@@ -25,13 +26,17 @@ public class ComplexConfiguration extends EclipseStoreClientConfiguration
 	
 	public static final String STORAGE_PATH = "storage-complex";
 	
+	private final ClassLoaderProvider classLoaderProvider;
+	
 	@Autowired
 	public ComplexConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider
 	)
 	{
 		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		this.classLoaderProvider = classLoaderProvider;
 	}
 	
 	/**
@@ -45,7 +50,11 @@ public class ComplexConfiguration extends EclipseStoreClientConfiguration
 	@Override
 	public EmbeddedStorageFoundation<?> createEmbeddedStorageFoundation()
 	{
-		return EmbeddedStorage.Foundation(Storage.Configuration(Storage.FileProvider(Path.of(STORAGE_PATH))));
+		final EmbeddedStorageFoundation<?> storageFoundation =
+			EmbeddedStorage.Foundation(Storage.Configuration(Storage.FileProvider(Path.of(STORAGE_PATH))));
+		// This is only needed, if a different ClassLoader is used (e.g. when using spring-dev-tools)
+		storageFoundation.getConnectionFoundation().setClassLoaderProvider(this.classLoaderProvider);
+		return storageFoundation;
 	}
 	
 	/**

--- a/spring-data-eclipse-store-demo/src/main/java/software/xdev/spring/data/eclipse/store/demo/complex/ComplexConfiguration.java
+++ b/spring-data-eclipse-store-demo/src/main/java/software/xdev/spring/data/eclipse/store/demo/complex/ComplexConfiguration.java
@@ -26,8 +26,6 @@ public class ComplexConfiguration extends EclipseStoreClientConfiguration
 	
 	public static final String STORAGE_PATH = "storage-complex";
 	
-	private final ClassLoaderProvider classLoaderProvider;
-	
 	@Autowired
 	public ComplexConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
@@ -35,8 +33,7 @@ public class ComplexConfiguration extends EclipseStoreClientConfiguration
 		final ClassLoaderProvider classLoaderProvider
 	)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
-		this.classLoaderProvider = classLoaderProvider;
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 	
 	/**
@@ -53,7 +50,7 @@ public class ComplexConfiguration extends EclipseStoreClientConfiguration
 		final EmbeddedStorageFoundation<?> storageFoundation =
 			EmbeddedStorage.Foundation(Storage.Configuration(Storage.FileProvider(Path.of(STORAGE_PATH))));
 		// This is only needed, if a different ClassLoader is used (e.g. when using spring-dev-tools)
-		storageFoundation.getConnectionFoundation().setClassLoaderProvider(this.classLoaderProvider);
+		storageFoundation.getConnectionFoundation().setClassLoaderProvider(this.getClassLoaderProvider());
 		return storageFoundation;
 	}
 	

--- a/spring-data-eclipse-store-demo/src/main/java/software/xdev/spring/data/eclipse/store/demo/dual/storage/invoice/PersistenceInvoiceConfiguration.java
+++ b/spring-data-eclipse-store-demo/src/main/java/software/xdev/spring/data/eclipse/store/demo/dual/storage/invoice/PersistenceInvoiceConfiguration.java
@@ -2,6 +2,7 @@ package software.xdev.spring.data.eclipse.store.demo.dual.storage.invoice;
 
 import java.nio.file.Path;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorage;
@@ -23,15 +24,18 @@ import software.xdev.spring.data.eclipse.store.repository.config.EnableEclipseSt
 @EnableEclipseStoreRepositories
 public class PersistenceInvoiceConfiguration extends EclipseStoreClientConfiguration
 {
-	
 	public static final String STORAGE_PATH = "storage-invoice";
+	
+	private final ClassLoaderProvider classLoaderProvider;
 	
 	@Autowired
 	protected PersistenceInvoiceConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
 		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		this.classLoaderProvider = classLoaderProvider;
 	}
 	
 	/**
@@ -45,6 +49,10 @@ public class PersistenceInvoiceConfiguration extends EclipseStoreClientConfigura
 	@Override
 	public EmbeddedStorageFoundation<?> createEmbeddedStorageFoundation()
 	{
-		return EmbeddedStorage.Foundation(Storage.Configuration(Storage.FileProvider(Path.of(STORAGE_PATH))));
+		final EmbeddedStorageFoundation<?> storageFoundation =
+			EmbeddedStorage.Foundation(Storage.Configuration(Storage.FileProvider(Path.of(STORAGE_PATH))));
+		// This is only needed, if a different ClassLoader is used (e.g. when using spring-dev-tools)
+		storageFoundation.getConnectionFoundation().setClassLoaderProvider(this.classLoaderProvider);
+		return storageFoundation;
 	}
 }

--- a/spring-data-eclipse-store-demo/src/main/java/software/xdev/spring/data/eclipse/store/demo/dual/storage/invoice/PersistenceInvoiceConfiguration.java
+++ b/spring-data-eclipse-store-demo/src/main/java/software/xdev/spring/data/eclipse/store/demo/dual/storage/invoice/PersistenceInvoiceConfiguration.java
@@ -26,16 +26,13 @@ public class PersistenceInvoiceConfiguration extends EclipseStoreClientConfigura
 {
 	public static final String STORAGE_PATH = "storage-invoice";
 	
-	private final ClassLoaderProvider classLoaderProvider;
-	
 	@Autowired
 	protected PersistenceInvoiceConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
 		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
 		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
-		this.classLoaderProvider = classLoaderProvider;
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 	
 	/**
@@ -52,7 +49,7 @@ public class PersistenceInvoiceConfiguration extends EclipseStoreClientConfigura
 		final EmbeddedStorageFoundation<?> storageFoundation =
 			EmbeddedStorage.Foundation(Storage.Configuration(Storage.FileProvider(Path.of(STORAGE_PATH))));
 		// This is only needed, if a different ClassLoader is used (e.g. when using spring-dev-tools)
-		storageFoundation.getConnectionFoundation().setClassLoaderProvider(this.classLoaderProvider);
+		storageFoundation.getConnectionFoundation().setClassLoaderProvider(getClassLoaderProvider());
 		return storageFoundation;
 	}
 }

--- a/spring-data-eclipse-store-demo/src/main/java/software/xdev/spring/data/eclipse/store/demo/dual/storage/person/PersistencePersonConfiguration.java
+++ b/spring-data-eclipse-store-demo/src/main/java/software/xdev/spring/data/eclipse/store/demo/dual/storage/person/PersistencePersonConfiguration.java
@@ -1,5 +1,6 @@
 package software.xdev.spring.data.eclipse.store.demo.dual.storage.person;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.ConfigurationPair;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
@@ -31,9 +32,10 @@ public class PersistencePersonConfiguration extends EclipseStoreClientConfigurat
 	public PersistencePersonConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
 		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
-		final EclipseStoreProperties properties)
+		final EclipseStoreProperties properties,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 		this.foundation = defaultEclipseStoreProvider;
 		this.properties = properties;
 	}

--- a/spring-data-eclipse-store-jpa/pom.xml
+++ b/spring-data-eclipse-store-jpa/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>software.xdev</groupId>
 		<artifactId>spring-data-eclipse-store-root</artifactId>
-		<version>2.2.3-SNAPSHOT</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-data-eclipse-store-jpa</artifactId>
-	<version>2.2.3-SNAPSHOT</version>
+	<version>2.3.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<inceptionYear>2023</inceptionYear>

--- a/spring-data-eclipse-store-jpa/src/test/java/software/xdev/spring/data/eclipse/store/jpa/integration/TestConfiguration.java
+++ b/spring-data-eclipse-store-jpa/src/test/java/software/xdev/spring/data/eclipse/store/jpa/integration/TestConfiguration.java
@@ -17,6 +17,7 @@ package software.xdev.spring.data.eclipse.store.jpa.integration;
 
 import java.nio.file.Path;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -45,9 +46,10 @@ public class TestConfiguration extends EclipseStoreClientConfiguration implement
 	@Autowired
 	protected TestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 	
 	@EventListener

--- a/spring-data-eclipse-store/pom.xml
+++ b/spring-data-eclipse-store/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>software.xdev</groupId>
 	<artifactId>spring-data-eclipse-store</artifactId>
-	<version>2.2.3-SNAPSHOT</version>
+	<version>2.3.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>spring-data-eclipse-store</name>

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/importer/EclipseStoreDataImporter.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/importer/EclipseStoreDataImporter.java
@@ -265,7 +265,8 @@ public class EclipseStoreDataImporter
 				storageInstance,
 				storageInstance,
 				new SupportedChecker.Implementation(),
-				storageInstance
+				storageInstance,
+				this.configuration.getClassLoaderProvider()
 			),
 			domainClass,
 			new EclipseStoreTransactionManager(),

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/EclipseStoreStorage.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/EclipseStoreStorage.java
@@ -25,6 +25,7 @@ import org.eclipse.serializer.persistence.binary.jdk17.java.util.BinaryHandlerIm
 import org.eclipse.serializer.persistence.binary.jdk17.java.util.BinaryHandlerImmutableCollectionsSet12;
 import org.eclipse.serializer.persistence.types.Storer;
 import org.eclipse.serializer.reference.ObjectSwizzling;
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageManager;
 import org.eclipse.store.storage.types.StorageManager;
@@ -69,6 +70,7 @@ public class EclipseStoreStorage
 	 */
 	private final Map<Class<?>, VersionManager<?>> versionManagers = new ConcurrentHashMap<>();
 	private final EclipseStoreStorageFoundationProvider foundationProvider;
+	private final ClassLoaderProvider classLoaderProvider;
 	private EntitySetCollector entitySetCollector;
 	private PersistableChecker persistenceChecker;
 	private EmbeddedStorageManager storageManager;
@@ -81,6 +83,7 @@ public class EclipseStoreStorage
 	public EclipseStoreStorage(final EclipseStoreClientConfiguration storeConfiguration)
 	{
 		this.foundationProvider = storeConfiguration;
+		this.classLoaderProvider = storeConfiguration.getClassLoaderProvider();
 	}
 	
 	private StorageManager getInstanceOfStorageManager()
@@ -92,6 +95,11 @@ public class EclipseStoreStorage
 	public WorkingCopyRegistry getRegistry()
 	{
 		return this.registry;
+	}
+	
+	public ClassLoaderProvider getClassLoaderProvider()
+	{
+		return this.classLoaderProvider;
 	}
 	
 	private synchronized void ensureEntitiesInRoot()

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/DefaultEclipseStoreClientConfiguration.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/DefaultEclipseStoreClientConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.repository.config;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.context.annotation.Configuration;
@@ -29,8 +30,9 @@ public class DefaultEclipseStoreClientConfiguration extends EclipseStoreClientCo
 {
 	protected DefaultEclipseStoreClientConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/DefaultEclipseStoreClientConfigurationFactory.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/DefaultEclipseStoreClientConfigurationFactory.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.repository.config;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -29,8 +30,12 @@ public class DefaultEclipseStoreClientConfigurationFactory
 	@ConditionalOnMissingBean(EclipseStoreClientConfiguration.class)
 	public DefaultEclipseStoreClientConfiguration getEclipseStoreClientConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		return new DefaultEclipseStoreClientConfiguration(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		return new DefaultEclipseStoreClientConfiguration(
+			defaultEclipseStoreProperties,
+			defaultEclipseStoreProvider,
+			classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java
@@ -18,6 +18,8 @@ package software.xdev.spring.data.eclipse.store.repository.config;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,6 +56,8 @@ import software.xdev.spring.data.eclipse.store.transactions.EclipseStoreTransact
 })
 public abstract class EclipseStoreClientConfiguration implements EclipseStoreStorageFoundationProvider
 {
+	private static final Logger LOG = LoggerFactory.getLogger(EclipseStoreClientConfiguration.class);
+	
 	protected final EclipseStoreProperties defaultEclipseStoreProperties;
 	protected final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider;
 	
@@ -157,7 +161,15 @@ public abstract class EclipseStoreClientConfiguration implements EclipseStoreSto
 		}
 		
 		// Spring Boot DevTools Restart enabled?
-		return this.springDevtoolsRestartEnabled;
+		final boolean enabled = this.springDevtoolsRestartEnabled;
+		if(enabled)
+		{
+			LOG.warn("Will shut down storage because Spring Boot DevTools Restarting is active. "
+				+ "This may cause some unexpected behavior. "
+				+ "For more information have a look at "
+				+ "https://spring-eclipsestore.xdev.software/known-issues.html#_spring_developer_tools");
+		}
+		return enabled;
 	}
 	
 	/**

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.repository.config;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
@@ -60,6 +61,7 @@ public abstract class EclipseStoreClientConfiguration implements EclipseStoreSto
 	
 	protected final EclipseStoreProperties defaultEclipseStoreProperties;
 	protected final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider;
+	protected final ClassLoaderProvider classLoaderProvider;
 	
 	protected EclipseStoreStorage storageInstance;
 	protected EclipseStoreTransactionManager transactionManager;
@@ -81,9 +83,11 @@ public abstract class EclipseStoreClientConfiguration implements EclipseStoreSto
 	@Autowired
 	protected EclipseStoreClientConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
 		this.defaultEclipseStoreProperties = defaultEclipseStoreProperties;
+		this.classLoaderProvider = classLoaderProvider;
 		this.defaultEclipseStoreProperties.setAutoStart(false);
 		this.defaultEclipseStoreProvider = defaultEclipseStoreProvider;
 	}
@@ -96,6 +100,11 @@ public abstract class EclipseStoreClientConfiguration implements EclipseStoreSto
 	public EmbeddedStorageFoundationFactory getStoreProvider()
 	{
 		return this.defaultEclipseStoreProvider;
+	}
+	
+	public ClassLoaderProvider getClassLoaderProvider()
+	{
+		return classLoaderProvider;
 	}
 	
 	/**

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java
@@ -64,6 +64,20 @@ public abstract class EclipseStoreClientConfiguration implements EclipseStoreSto
 	protected EclipseStoreStorage storageInstance;
 	protected EclipseStoreTransactionManager transactionManager;
 	
+	@Value("${spring-data-eclipse-store.context-close-shutdown-storage.enabled:true}")
+	protected boolean contextCloseShutdownStorageEnabled;
+	
+	@Value("${spring-data-eclipse-store.context-close-shutdown-storage.only-when-dev-tools:true}")
+	protected boolean contextCloseShutdownStorageOnlyWhenDevTools;
+	
+	/**
+	 * Upstream value from Spring Boot DevTools.
+	 *
+	 * @see org.springframework.boot.devtools.autoconfigure.DevToolsProperties.Restart
+	 */
+	@Value("${spring.devtools.restart.enabled:true}")
+	protected boolean springDevtoolsRestartEnabled;
+	
 	@Autowired
 	protected EclipseStoreClientConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
@@ -119,22 +133,6 @@ public abstract class EclipseStoreClientConfiguration implements EclipseStoreSto
 		}
 		return this.transactionManager;
 	}
-	
-	// region On context closed shutdown storage
-	
-	@Value("${spring-data-eclipse-store.context-close-shutdown-storage.enabled:true}")
-	protected boolean contextCloseShutdownStorageEnabled;
-	
-	@Value("${spring-data-eclipse-store.context-close-shutdown-storage.only-when-dev-tools:true}")
-	protected boolean contextCloseShutdownStorageOnlyWhenDevTools;
-	
-	/**
-	 * Upstream value from Spring Boot DevTools.
-	 *
-	 * @see org.springframework.boot.devtools.autoconfigure.DevToolsProperties.Restart
-	 */
-	@Value("${spring.devtools.restart.enabled:true}")
-	protected boolean springDevtoolsRestartEnabled;
 	
 	protected boolean shouldShutdownStorageOnContextClosed()
 	{
@@ -192,6 +190,4 @@ public abstract class EclipseStoreClientConfiguration implements EclipseStoreSto
 			this.storageInstance.stop();
 		}
 	}
-	
-	// endregion
 }

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java
@@ -51,11 +51,11 @@ import software.xdev.spring.data.eclipse.store.transactions.EclipseStoreTransact
 })
 public abstract class EclipseStoreClientConfiguration implements EclipseStoreStorageFoundationProvider
 {
-	private final EclipseStoreProperties defaultEclipseStoreProperties;
-	private final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider;
+	protected final EclipseStoreProperties defaultEclipseStoreProperties;
+	protected final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider;
 	
-	private EclipseStoreStorage storageInstance;
-	private EclipseStoreTransactionManager transactionManager;
+	protected EclipseStoreStorage storageInstance;
+	protected EclipseStoreTransactionManager transactionManager;
 	
 	@Autowired
 	protected EclipseStoreClientConfiguration(

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/config/EclipseStoreClientConfiguration.java
@@ -99,10 +99,9 @@ public abstract class EclipseStoreClientConfiguration implements EclipseStoreSto
 	public PlatformTransactionManager transactionManager(
 		final ObjectProvider<TransactionManagerCustomizers> transactionManagerCustomizers)
 	{
-		final EclipseStoreTransactionManager transactionManager = this.getTransactionManagerInstance();
-		transactionManagerCustomizers.ifAvailable((customizers) ->
-			customizers.customize((TransactionManager)transactionManager));
-		return transactionManager;
+		final EclipseStoreTransactionManager tm = this.getTransactionManagerInstance();
+		transactionManagerCustomizers.ifAvailable(customizers -> customizers.customize((TransactionManager)tm));
+		return tm;
 	}
 	
 	public EclipseStoreTransactionManager getTransactionManagerInstance()

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/EclipseStoreRepositoryFactory.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/EclipseStoreRepositoryFactory.java
@@ -82,7 +82,8 @@ public class EclipseStoreRepositoryFactory extends RepositoryFactorySupport
 			storage,
 			storage,
 			new SupportedChecker.Implementation(),
-			storage
+			storage,
+			storage.getClassLoaderProvider()
 		);
 	}
 	

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/AbstractRegisteringCopier.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/AbstractRegisteringCopier.java
@@ -59,8 +59,7 @@ public abstract class AbstractRegisteringCopier implements RegisteringObjectCopi
 				this.createSerializerFoundation(),
 				objectSwizzling,
 				copier,
-				currentClassLoaderProvider,
-				copier
+				currentClassLoaderProvider
 			),
 			validator
 		);

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/AbstractRegisteringCopier.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/AbstractRegisteringCopier.java
@@ -23,6 +23,7 @@ import org.eclipse.serializer.persistence.binary.types.Binary;
 import org.eclipse.serializer.persistence.types.PersistenceManager;
 import org.eclipse.serializer.reference.ObjectSwizzling;
 import org.eclipse.serializer.reference.Reference;
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.serializer.util.X;
 
 import software.xdev.spring.data.eclipse.store.repository.SupportedChecker;
@@ -37,12 +38,15 @@ import software.xdev.spring.data.eclipse.store.repository.support.copier.working
 public abstract class AbstractRegisteringCopier implements RegisteringObjectCopier
 {
 	private final EclipseSerializerRegisteringCopier actualCopier;
+	private ClassLoader currentClassLoader;
 	
 	protected AbstractRegisteringCopier(
 		final SupportedChecker supportedChecker,
 		final RegisteringWorkingCopyAndOriginal register,
 		final ObjectSwizzling objectSwizzling,
-		final WorkingCopier<?> copier)
+		final WorkingCopier<?> copier,
+		final ClassLoaderProvider currentClassLoaderProvider
+	)
 	{
 		this.actualCopier = new EclipseSerializerRegisteringCopier(
 			supportedChecker,
@@ -51,7 +55,8 @@ public abstract class AbstractRegisteringCopier implements RegisteringObjectCopi
 			this.createPersistenceManager(
 				this.createSerializerFoundation(),
 				objectSwizzling,
-				copier
+				copier,
+				currentClassLoaderProvider
 			)
 		);
 	}
@@ -59,9 +64,11 @@ public abstract class AbstractRegisteringCopier implements RegisteringObjectCopi
 	private PersistenceManager<Binary> createPersistenceManager(
 		final SerializerFoundation<?> serializerFoundation,
 		final ObjectSwizzling objectSwizzling,
-		final WorkingCopier<?> copier)
+		final WorkingCopier<?> copier,
+		final ClassLoaderProvider currentClassLoaderProvider)
 	{
 		return serializerFoundation
+			.setClassLoaderProvider(currentClassLoaderProvider)
 			.registerCustomTypeHandler(BinaryHandlerImmutableCollectionsSet12.New())
 			.registerCustomTypeHandler(BinaryHandlerImmutableCollectionsList12.New())
 			.registerCustomTypeHandlers(new SpringDataEclipseStoreLazyBinaryHandler(objectSwizzling, copier))

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/EclipseSerializerRegisteringCopier.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/EclipseSerializerRegisteringCopier.java
@@ -116,7 +116,7 @@ public class EclipseSerializerRegisteringCopier implements AutoCloseable
 	{
 		persistenceManager.objectRegistry().truncateAll();
 		final BinaryStorer.Default storer = (BinaryStorer.Default)persistenceManager.createStorer();
-		// Loader erstellen
+		// Create Loader
 		final PersistenceLoader loader = persistenceManager.createLoader();
 		
 		storer.store(source);

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/RegisteringStorageToWorkingCopyCopier.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/RegisteringStorageToWorkingCopyCopier.java
@@ -16,6 +16,7 @@
 package software.xdev.spring.data.eclipse.store.repository.support.copier.registering;
 
 import org.eclipse.serializer.reference.ObjectSwizzling;
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 
 import software.xdev.spring.data.eclipse.store.repository.SupportedChecker;
 import software.xdev.spring.data.eclipse.store.repository.WorkingCopyRegistry;
@@ -32,13 +33,15 @@ public class RegisteringStorageToWorkingCopyCopier extends AbstractRegisteringCo
 		final WorkingCopyRegistry registry,
 		final SupportedChecker supportedChecker,
 		final ObjectSwizzling objectSwizzling,
-		final WorkingCopier<?> copier)
+		final WorkingCopier<?> copier,
+		final ClassLoaderProvider currentClassLoaderProvider)
 	{
 		super(
 			supportedChecker,
 			registry::register,
 			objectSwizzling,
-			copier
+			copier,
+			currentClassLoaderProvider
 		);
 	}
 }

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/RegisteringWorkingCopyToStorageCopier.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/RegisteringWorkingCopyToStorageCopier.java
@@ -16,6 +16,7 @@
 package software.xdev.spring.data.eclipse.store.repository.support.copier.registering;
 
 import org.eclipse.serializer.reference.ObjectSwizzling;
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 
 import software.xdev.spring.data.eclipse.store.repository.SupportedChecker;
 import software.xdev.spring.data.eclipse.store.repository.WorkingCopyRegistry;
@@ -33,13 +34,15 @@ public class RegisteringWorkingCopyToStorageCopier extends AbstractRegisteringCo
 		final WorkingCopyRegistry registry,
 		final SupportedChecker supportedChecker,
 		final ObjectSwizzling objectSwizzling,
-		final WorkingCopier<?> copier)
+		final WorkingCopier<?> copier,
+		final ClassLoaderProvider currentClassLoaderProvider)
 	{
 		super(
 			supportedChecker,
 			registry::invertRegister,
 			objectSwizzling,
-			copier
+			copier,
+			currentClassLoaderProvider
 		);
 	}
 }

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/working/RecursiveWorkingCopier.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/working/RecursiveWorkingCopier.java
@@ -30,6 +30,7 @@ import java.util.TreeSet;
 
 import org.eclipse.serializer.reference.Lazy;
 import org.eclipse.serializer.reference.ObjectSwizzling;
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,15 +73,26 @@ public class RecursiveWorkingCopier<T> implements WorkingCopier<T>
 		final VersionManagerProvider versionManagerProvider,
 		final PersistableChecker persistableChecker,
 		final SupportedChecker supportedChecker,
-		final ObjectSwizzling objectSwizzling
+		final ObjectSwizzling objectSwizzling,
+		final ClassLoaderProvider currentClassLoaderProvider
 	)
 	{
 		this.domainClass = domainClass;
 		this.registry = registry;
 		this.workingCopyToStorageCopier =
-			new RegisteringWorkingCopyToStorageCopier(registry, supportedChecker, objectSwizzling, this);
+			new RegisteringWorkingCopyToStorageCopier(
+				registry,
+				supportedChecker,
+				objectSwizzling,
+				this,
+				currentClassLoaderProvider);
 		this.storageToWorkingCopyCopier =
-			new RegisteringStorageToWorkingCopyCopier(registry, supportedChecker, objectSwizzling, this);
+			new RegisteringStorageToWorkingCopyCopier(
+				registry,
+				supportedChecker,
+				objectSwizzling,
+				this,
+				currentClassLoaderProvider);
 		this.idManagerProvider = idManagerProvider;
 		this.versionManagerProvider = versionManagerProvider;
 		this.persistableChecker = persistableChecker;

--- a/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/working/RecursiveWorkingCopier.java
+++ b/spring-data-eclipse-store/src/main/java/software/xdev/spring/data/eclipse/store/repository/support/copier/working/RecursiveWorkingCopier.java
@@ -88,6 +88,7 @@ public class RecursiveWorkingCopier<T> implements WorkingCopier<T>
 				supportedChecker,
 				objectSwizzling,
 				this,
+				validator,
 				currentClassLoaderProvider);
 		this.storageToWorkingCopyCopier =
 			new RegisteringStorageToWorkingCopyCopier(
@@ -95,10 +96,8 @@ public class RecursiveWorkingCopier<T> implements WorkingCopier<T>
 				supportedChecker,
 				objectSwizzling,
 				this,
+				validator,
 				currentClassLoaderProvider);
-			new RegisteringWorkingCopyToStorageCopier(registry, supportedChecker, objectSwizzling, this, validator);
-		this.storageToWorkingCopyCopier =
-			new RegisteringStorageToWorkingCopyCopier(registry, supportedChecker, objectSwizzling, this, validator);
 		this.idManagerProvider = idManagerProvider;
 		this.versionManagerProvider = versionManagerProvider;
 		this.persistableChecker = persistableChecker;

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/TestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/TestConfiguration.java
@@ -20,6 +20,7 @@ import static org.eclipse.store.storage.embedded.types.EmbeddedStorage.Foundatio
 import java.io.IOException;
 import java.nio.file.Path;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.eclipse.store.storage.embedded.types.EmbeddedStorageFoundation;
@@ -43,9 +44,10 @@ public class TestConfiguration extends EclipseStoreClientConfiguration
 	@Autowired
 	protected TestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 	
 	@Override

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/constraints/ConstraintsTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/constraints/ConstraintsTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.constraints;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,9 @@ public class ConstraintsTestConfiguration extends TestConfiguration
 	@Autowired
 	protected ConstraintsTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/deletion/DeletionTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/deletion/DeletionTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.deletion;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,8 +33,9 @@ public class DeletionTestConfiguration extends TestConfiguration
 	@Autowired
 	protected DeletionTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/duplicated/repositories/DuplicatedRepositoriesTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/duplicated/repositories/DuplicatedRepositoriesTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.duplicated.repositories;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,8 +33,9 @@ public class DuplicatedRepositoriesTestConfiguration extends TestConfiguration
 	@Autowired
 	protected DuplicatedRepositoriesTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/id/IdTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/id/IdTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.id;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -35,9 +36,10 @@ public class IdTestConfiguration extends TestConfiguration
 	@Autowired
 	protected IdTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 	
 	@Bean

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/immutables/ImmutableTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/immutables/ImmutableTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.immutables;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,8 +33,9 @@ public class ImmutableTestConfiguration extends TestConfiguration
 	@Autowired
 	protected ImmutableTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/keywords/KeywordsTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/keywords/KeywordsTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.keywords;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,9 @@ public class KeywordsTestConfiguration extends TestConfiguration
 	@Autowired
 	protected KeywordsTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/lazy/LazyTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/lazy/LazyTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.lazy;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,8 +33,9 @@ public class LazyTestConfiguration extends TestConfiguration
 	@Autowired
 	protected LazyTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/migration/MigrationTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/migration/MigrationTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.migration;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,9 @@ public class MigrationTestConfiguration extends TestConfiguration
 	@Autowired
 	protected MigrationTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/query/by/example/QueryByExampleTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/query/by/example/QueryByExampleTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.query.by.example;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,9 @@ public class QueryByExampleTestConfiguration extends TestConfiguration
 	@Autowired
 	protected QueryByExampleTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/query/by/string/QueryTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/query/by/string/QueryTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.query.by.string;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,9 @@ public class QueryTestConfiguration extends TestConfiguration
 	@Autowired
 	protected QueryTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/query/hsql/HsqlTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/query/hsql/HsqlTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.query.hsql;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,9 @@ public class HsqlTestConfiguration extends TestConfiguration
 	@Autowired
 	protected HsqlTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/special/types/SpecialTypesTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/special/types/SpecialTypesTestConfiguration.java
@@ -35,6 +35,6 @@ public class SpecialTypesTestConfiguration extends TestConfiguration
 		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
 		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider,classLoaderProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/special/types/SpecialTypesTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/special/types/SpecialTypesTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.special.types;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,9 @@ public class SpecialTypesTestConfiguration extends TestConfiguration
 	@Autowired
 	protected SpecialTypesTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider,classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/transactions/TransactionsTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/transactions/TransactionsTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.transactions;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -35,9 +36,10 @@ public class TransactionsTestConfiguration extends TestConfiguration
 	@Autowired
 	protected TransactionsTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 	
 	@Bean

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/version/VersionTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/isolated/tests/version/VersionTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.isolated.tests.version;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -35,9 +36,10 @@ public class VersionTestConfiguration extends TestConfiguration
 	@Autowired
 	protected VersionTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 	
 	@Bean

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/shared/SharedTestConfiguration.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/integration/shared/SharedTestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package software.xdev.spring.data.eclipse.store.integration.shared;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.eclipse.store.integrations.spring.boot.types.configuration.EclipseStoreProperties;
 import org.eclipse.store.integrations.spring.boot.types.factories.EmbeddedStorageFoundationFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +32,9 @@ public class SharedTestConfiguration extends TestConfiguration
 	@Autowired
 	protected SharedTestConfiguration(
 		final EclipseStoreProperties defaultEclipseStoreProperties,
-		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider)
+		final EmbeddedStorageFoundationFactory defaultEclipseStoreProvider,
+		final ClassLoaderProvider classLoaderProvider)
 	{
-		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider);
+		super(defaultEclipseStoreProperties, defaultEclipseStoreProvider, classLoaderProvider);
 	}
 }

--- a/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/RegisteringStorageToWorkingCopyCopierTest.java
+++ b/spring-data-eclipse-store/src/test/java/software/xdev/spring/data/eclipse/store/repository/support/copier/registering/RegisteringStorageToWorkingCopyCopierTest.java
@@ -18,6 +18,7 @@ package software.xdev.spring.data.eclipse.store.repository.support.copier.regist
 import java.util.List;
 import java.util.stream.IntStream;
 
+import org.eclipse.serializer.reflect.ClassLoaderProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +41,8 @@ class RegisteringStorageToWorkingCopyCopierTest
 				new WorkingCopyRegistry(),
 				new SupportedChecker.Implementation(),
 				o -> null,
-				new DummyWorkingCopier()))
+				new DummyWorkingCopier(),
+				ClassLoaderProvider.System()))
 		{
 			final List<DummyData> originalObjects = IntStream.range(0, 1_000).mapToObj(
 				i -> new DummyData("Data" + i, i)
@@ -60,7 +62,8 @@ class RegisteringStorageToWorkingCopyCopierTest
 				new WorkingCopyRegistry(),
 				new SupportedChecker.Implementation(),
 				o -> null,
-				new DummyWorkingCopier()))
+				new DummyWorkingCopier(),
+				ClassLoaderProvider.System()))
 		{
 			final DummyData originalObject = new DummyData("Test", 1);
 			
@@ -79,7 +82,8 @@ class RegisteringStorageToWorkingCopyCopierTest
 				new WorkingCopyRegistry(),
 				new SupportedChecker.Implementation(),
 				o -> null,
-				new DummyWorkingCopier()))
+				new DummyWorkingCopier(),
+				ClassLoaderProvider.System()))
 		{
 			final DummyData originalObject = new DummyData("Test", 1);
 			
@@ -100,7 +104,8 @@ class RegisteringStorageToWorkingCopyCopierTest
 				new WorkingCopyRegistry(),
 				new SupportedChecker.Implementation(),
 				o -> null,
-				new DummyWorkingCopier()))
+				new DummyWorkingCopier(),
+				ClassLoaderProvider.System()))
 		{
 			final List<DummyData> originalObjects = IntStream.range(0, 100_000).mapToObj(
 				i -> new DummyData("Data" + i, i)
@@ -120,7 +125,8 @@ class RegisteringStorageToWorkingCopyCopierTest
 				new WorkingCopyRegistry(),
 				new SupportedChecker.Implementation(),
 				o -> null,
-				new DummyWorkingCopier()))
+				new DummyWorkingCopier(),
+				ClassLoaderProvider.System()))
 		{
 			Assertions.assertThrows(NullPointerException.class, () -> copier.copy(null));
 		}


### PR DESCRIPTION
* Add support for shuting down the storage during application shutdown
  * By default only enabled when Spring DevTools are active
    * This should fix "StorageExceptionInitialization: Active storage for ... already exists" errors during DevTools restart
